### PR TITLE
Resource cloning is no longer supported by chef.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -35,9 +35,5 @@ registry_key 'HKEY_LOCAL_MACHINE\Software\Microsoft\Rpc\Internet' do
 end
 
 windows_service 'MSDTC' do
-  action :enable
-end
-
-windows_service 'MSDTC' do
-  action :start
+  action [ :enable, :start ]
 end


### PR DESCRIPTION
See https://docs.chef.io/deprecations_resource_cloning.html for further details.